### PR TITLE
Fix inconsistency with Adafruit_DHT/common.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A plugin allowing the [Cayenne Pi Agent](https://github.com/myDevicesIoT/Cayenne
 ### 2. Setting the sensor type and pin
 
    Specify the sensor type and pin you are using by modifying `init_args` under `DHT Temperature` in the `cayenne_dht.plugin` file.
-   For a DHT11 use `11` for the sensor argument, for a DHT22 use `22` and for a AM2302 use `2302`. Set the pin argument to the GPIO
+   For a DHT11 use `11` for the sensor argument, for a DHT22 use `22` and for a AM2302 use `22`. Set the pin argument to the GPIO
    pin number your sensor is connected to. For example, a DHT11 on pin 17 would use the following:
    ```
    init_args={"sensor": 11, "pin": 17}


### PR DESCRIPTION
Current Adafruit_DHT/common.py contains:
# Define sensor type constants.
DHT11  = 11
DHT22  = 22
AM2302 = 22
SENSORS = [DHT11, DHT22, AM2302]

When 2302 is used as the "sensor" inside cayenne_dht.plugin, the ValueError message is hit because the value 2302 is not in SENSORS.
    if sensor not in SENSORS:
	raise ValueError('Expected DHT11, DHT22, or AM2302 sensor value.')

Everything works fine if "SENSORS" is set to 22 while using an AM2302 (my setup).